### PR TITLE
Fix serial port access by switching to --device=all

### DIFF
--- a/com.k0vcz.Artemis.json
+++ b/com.k0vcz.Artemis.json
@@ -8,7 +8,7 @@
         "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
-        "--device=dri",
+        "--device=all",
         "--socket=wayland"
     ],
     "cleanup": [
@@ -102,8 +102,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/jaybaird/artemis.git",
-                    "tag": "v1.0.1",
-                    "commit": "ac3d7f0846a3f00fefae15bd4f045b28f6f5d68a"
+                    "tag": "v1.0.2",
+                    "commit": "1605c72b16c430fca9b16d6824bda31b08164759"
                 }
             ]
         }


### PR DESCRIPTION
Closes #1. Switch to `--device=all`, update tag and commit SHA.